### PR TITLE
Only deploy Pages on push to main; PRs just build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,46 +8,55 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: read
-      pages: write
-      id-token: write
-    
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
-      
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build SvelteKit site
         run: npm run build
-      
+
       - name: Copy deployment files
         run: |
           cp CNAME build/
-      
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: './build'
-      
+
+  deploy:
+    # PRs only build as a CI check; only pushes to main deploy
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The `Deploy to GitHub Pages` workflow triggers on `pull_request`, but its single `build-and-deploy` job runs under the `github-pages` environment, whose deployment branch policy only allows `main`. Every PR run was therefore rejected before any step executed:

> Branch "refs/pull/48/merge" is not allowed to deploy to github-pages due to environment protection rules.

This blocked all PRs, including pixbot's photo submissions (e.g. #48).

## Fix

Split the workflow into two jobs:

- **build** — runs on PRs and pushes; installs deps, builds the SvelteKit site, uploads the Pages artifact. PRs keep a meaningful CI check.
- **deploy** — `needs: build`, skipped on `pull_request` events; holds the `github-pages` environment and the `pages: write` / `id-token: write` permissions, so only pushes to `main` (and manual dispatches) actually deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)